### PR TITLE
Add support for improved development workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 
 # Go workspace file
 go.work
+/.idea/

--- a/comms/comms.go
+++ b/comms/comms.go
@@ -8,37 +8,48 @@ import (
 	api_v1 "github.com/vision-cli/api/v1"
 	"github.com/vision-cli/common/execute"
 	"github.com/vision-cli/common/marshal"
+	"github.com/vision-cli/common/plugins"
+	"github.com/vision-cli/common/tmpl"
 )
 
-func Call[T any](plugin string, request *api_v1.PluginRequest, executor execute.Executor) (*T, error) {
+func Call[T any](plugin plugins.Plugin, request *api_v1.PluginRequest, executor execute.Executor) (*T, error) {
 	if request == nil {
 		return nil, fmt.Errorf("comms.Call called with nil request")
 	}
 	if executor == nil {
 		return nil, fmt.Errorf("comms.Call called with nil executor")
 	}
-	cmd := exec.Command(plugin)
+	cmd := exec.Command(plugin.PluginPath)
 	query, err := marshal.Marshal(request)
 	if err != nil {
-		return nil, fmt.Errorf("cannot marshal request for plugin %s: %s", plugin, err.Error())
+		return nil, fmt.Errorf("cannot marshal request for plugin %s: %s", plugin.Name, err.Error())
 	}
 	cmd.Stdin = strings.NewReader(query)
-	response, err := executor.Output(cmd, ".", "calling plugin "+plugin)
-	if err != nil {
-		return nil, fmt.Errorf("cannot run plugin %s", plugin)
+
+	var response string
+	if plugin.InternalCommand == nil {
+		execResponse, err := executor.Output(cmd, ".", "calling plugin "+plugin.Name)
+		if err != nil {
+			return nil, fmt.Errorf("cannot run plugin %s", plugin.Name)
+		}
+		response = execResponse
+	} else {
+		templateWriter := tmpl.NewOsTmpWriter()
+		response = plugin.InternalCommand(query, executor, templateWriter)
 	}
+
 	out, err := marshal.Unmarshal[T](response)
 	if err != nil {
 		// check if the response is an error
 		outerr, err := marshal.Unmarshal[api_v1.PluginResponse](response)
 		if err != nil {
-			return nil, fmt.Errorf("cannot unmarshal response from plugin %s: %s", plugin, err.Error())
+			return nil, fmt.Errorf("cannot unmarshal response from plugin %s: %s", plugin.Name, err.Error())
 		}
 		if outerr.Error != "" {
 			return nil, fmt.Errorf(outerr.Error)
 		}
 		return nil,
-			fmt.Errorf("did not get expected result type from %s:, got PluginResponse with result %s", plugin, outerr.Result)
+			fmt.Errorf("did not get expected result type from %s:, got PluginResponse with result %s", plugin.Name, outerr.Result)
 	}
 	return &out, nil
 }

--- a/comms/comms_test.go
+++ b/comms/comms_test.go
@@ -2,6 +2,8 @@ package comms_test
 
 import (
 	"fmt"
+	"github.com/vision-cli/common/execute"
+	"github.com/vision-cli/common/tmpl"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -49,6 +51,20 @@ func TestCall_WhenReturnIsNotExpectStructButAlsoNotError_ReturnsError(t *testing
 	_, err := comms.Call[TestMsg](plugin, &pluginRequest, &e)
 	require.Error(t, err)
 	require.Equal(t, "did not get expected result type from plugin:, got PluginResponse with result some result", err.Error())
+}
+
+func TestCall_WhenInternalReturnIsValid_ReturnsStruct(t *testing.T) {
+	e := mocks.NewMockExecutor()
+	plugin := plugins.Plugin{
+		Name:       "internal-plugin",
+		PluginPath: "internal-plugin",
+		InternalCommand: func(_ string, _ execute.Executor, _ tmpl.TmplWriter) string {
+			return `{"Msg":"hello"}`
+		},
+	}
+	result, err := comms.Call[TestMsg](plugin, &pluginRequest, &e)
+	require.NoError(t, err)
+	require.Equal(t, "hello", result.Msg)
 }
 
 func TestCall_WhenExecutorFails_ReturnsError(t *testing.T) {

--- a/comms/comms_test.go
+++ b/comms/comms_test.go
@@ -8,22 +8,29 @@ import (
 	api_v1 "github.com/vision-cli/api/v1"
 	"github.com/vision-cli/common/comms"
 	"github.com/vision-cli/common/mocks"
+	"github.com/vision-cli/common/plugins"
 )
 
+var plugin = plugins.Plugin{
+	Name:            "plugin",
+	PluginPath:      "plugin",
+	InternalCommand: nil,
+}
+
 func TestCall_WhenRequestIsNil_ReturnsError(t *testing.T) {
-	_, err := comms.Call[int]("plugin", nil, nil)
+	_, err := comms.Call[int](plugin, nil, nil)
 	require.Error(t, err)
 }
 
 func TestCall_WhenExecutorIsNil_ReturnsError(t *testing.T) {
-	_, err := comms.Call[int]("plugin", &pluginRequest, nil)
+	_, err := comms.Call[int](plugin, &pluginRequest, nil)
 	require.Error(t, err)
 }
 
 func TestCall_WhenReturnIsValid_ReturnsStruct(t *testing.T) {
 	e := mocks.NewMockExecutor()
 	e.SetOutput(`{"Msg":"hello"}`)
-	result, err := comms.Call[TestMsg]("plugin", &pluginRequest, &e)
+	result, err := comms.Call[TestMsg](plugin, &pluginRequest, &e)
 	require.NoError(t, err)
 	require.Equal(t, "hello", result.Msg)
 }
@@ -31,7 +38,7 @@ func TestCall_WhenReturnIsValid_ReturnsStruct(t *testing.T) {
 func TestCall_WhenReturnIsInvalid_ReturnsError(t *testing.T) {
 	e := mocks.NewMockExecutor()
 	e.SetOutput(`{"Result":"","Error":"some error"}`)
-	_, err := comms.Call[TestMsg]("plugin", &pluginRequest, &e)
+	_, err := comms.Call[TestMsg](plugin, &pluginRequest, &e)
 	require.Error(t, err)
 	require.Equal(t, "some error", err.Error())
 }
@@ -39,7 +46,7 @@ func TestCall_WhenReturnIsInvalid_ReturnsError(t *testing.T) {
 func TestCall_WhenReturnIsNotExpectStructButAlsoNotError_ReturnsError(t *testing.T) {
 	e := mocks.NewMockExecutor()
 	e.SetOutput(`{"Result":"some result","Error":""}`)
-	_, err := comms.Call[TestMsg]("plugin", &pluginRequest, &e)
+	_, err := comms.Call[TestMsg](plugin, &pluginRequest, &e)
 	require.Error(t, err)
 	require.Equal(t, "did not get expected result type from plugin:, got PluginResponse with result some result", err.Error())
 }
@@ -47,7 +54,7 @@ func TestCall_WhenReturnIsNotExpectStructButAlsoNotError_ReturnsError(t *testing
 func TestCall_WhenExecutorFails_ReturnsError(t *testing.T) {
 	e := mocks.NewMockExecutor()
 	e.SetOutputErr(fmt.Errorf("error"))
-	_, err := comms.Call[int]("plugin", &pluginRequest, &e)
+	_, err := comms.Call[int](plugin, &pluginRequest, &e)
 	require.Error(t, err)
 }
 

--- a/plugins/plugins_test.go
+++ b/plugins/plugins_test.go
@@ -70,7 +70,7 @@ func TestGoGetPlugins_ReturnsAllValidPlugins(t *testing.T) {
 	e := mocks.NewMockExecutor()
 	result, err := plugins.GetPlugins(&e)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"vision-plugin-myplugin-v2"}, result)
+	assert.Equal(t, []plugins.Plugin{{"vision-plugin-myplugin-v2", "/usr/local/go/bin/vision-plugin-myplugin-v2", nil}}, result)
 }
 
 type MockDirEntry struct {


### PR DESCRIPTION
Support a monolithic build with embedded plugins, triggered by the 'vision_dev' build tag. This allows running the full vision-cli system including plugins in a single debuggable executable.
https://github.com/vision-cli/vision/issues/5